### PR TITLE
Makefile: un-phony golint target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,18 +5,18 @@ github.com/Clever/gearcmd/gearcmd \
 github.com/Clever/gearcmd/argsparser
 PKGS := $(PKG) $(SUBPKGS)
 
-.PHONY: test golint
+.PHONY: test
 
-golint:
+$(GOPATH)/bin/golint:
 	@go get github.com/golang/lint/golint
 
 test: $(PKGS)
 
-$(PKGS): golint
+$(PKGS): $(GOPATH)/bin/golint
 	@go get -d -t $@
 	@gofmt -w=true $(GOPATH)/src/$@*/**.go
 	@echo "LINTING..."
-	@PATH=$(PATH):$(GOPATH)/bin golint $(GOPATH)/src/$@*/**.go
+	@$(GOPATH)/bin/golint $(GOPATH)/src/$@*/**.go
 	@echo ""
 ifeq ($(COVERAGE),1)
 	@go test -cover -coverprofile=$(GOPATH)/src/$@/c.out $@ -test.v


### PR DESCRIPTION
since `go get ...golint` results in the creation of $GOPATH/bin/golint, it can be made into a proper Makefile target.
