### PR TITLE
Forward stderr to warnings on job failure

### DIFF
--- a/gearcmd/testscripts/logStderrFail.sh
+++ b/gearcmd/testscripts/logStderrFail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for i in 1 2 3 4 5 6 7 8
+do
+        >&2 echo "stderr${i}"
+done
+
+exit 2

--- a/gearcmd/worker_test.go
+++ b/gearcmd/worker_test.go
@@ -78,3 +78,12 @@ func TestHandleStderrAndStdoutTogether(t *testing.T) {
 	assert.Equal(t, "stderr2", string(lastWarning))
 	assert.Equal(t, "stdout1\nstdout2\n", string(mockJob.OutData()))
 }
+
+func TestStderrCapturedWarningsOnFailedJobs(t *testing.T) {
+	mockJob := mock.CreateMockJob("IgnorePayload")
+	config := TaskConfig{FunctionName: "name", FunctionCmd: "testscripts/logStderrFail.sh", WarningLines: 2}
+	_, err := config.Process(mockJob)
+	assert.Error(t, err)
+	warnings := mockJob.Warnings()
+	assert.Equal(t, warnings, [][]byte{[]byte("stderr7"), []byte("stderr8")})
+}


### PR DESCRIPTION
This fixes a bug where we weren't sending stderr lines as gearman
warnings if the job failed.
