### PR TITLE
Add ParseArgs command line flag

### DIFF
--- a/cmd/gearcmd/main.go
+++ b/cmd/gearcmd/main.go
@@ -15,6 +15,7 @@ func main() {
 	functionCmd := flag.String("cmd", "", "The command to run")
 	gearmanHost := flag.String("host", "localhost", "The Gearman host")
 	gearmanPort := flag.String("port", "4730", "The Gearman port")
+	parseArgs := flag.Bool("parseargs", true, "If false send the job payload directly to the cmd as its first argument without parsing it")
 	printVersion := flag.Bool("version", false, "Print the version and exit")
 	flag.Parse()
 
@@ -34,7 +35,7 @@ func main() {
 		os.Exit(3)
 	}
 
-	config := gearcmd.TaskConfig{FunctionName: *functionName, FunctionCmd: *functionCmd, WarningLines: 5}
+	config := gearcmd.TaskConfig{FunctionName: *functionName, FunctionCmd: *functionCmd, WarningLines: 5, ParseArgs: *parseArgs}
 	worker := baseworker.NewWorker(*functionName, config.Process)
 	defer worker.Close()
 	log.Printf("Listening for job: " + *functionName)


### PR DESCRIPTION
Adding a ParseArgs command line flag to gearcmd to support sending json
as payloads.

For example, before this change the json payload {"key":"value"} would
get parsed by bash into {key:value} (ie without the quotes) which is
invalid json. We decided the easiest way to address this was to add a
flag that allowed the user to bypass any parsing and send the raw
payload to the worker.
