### PR TITLE
actually kill the timed out process

### DIFF
--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -117,6 +117,9 @@ func (conf TaskConfig) doProcess(job baseworker.Job) error {
 		// Will be nil if the channel was closed without any errors
 		return err
 	case <-time.After(conf.CmdTimeout):
+		if err := cmd.Process.Kill(); err != nil {
+			return fmt.Errorf("process timeout after %s. error: %s", conf.CmdTimeout.String(), err.Error())
+		}
 		return fmt.Errorf("process timed out after %s", conf.CmdTimeout.String())
 	}
 }


### PR DESCRIPTION
When the process times out, we want to kill it and keep processing jobs. Right now we keep processing jobs, but leave the process hanging around.