### PR TITLE
[DATA-899] Adding gauge logging to END events for workers

### DIFF
--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -30,8 +30,8 @@ type TaskConfig struct {
 // though the byte[] is always nil.
 func (conf TaskConfig) Process(job baseworker.Job) ([]byte, error) {
 	// This wraps the actual processing to do some logging
-	log.Printf(kayvee.FormatLog("gearcmd", "info", "START",
-		map[string]interface{}{"function_name": conf.FunctionName, "job_id": getJobId(job), "job_data": string(job.Data())}))
+	log.Println(kayvee.FormatLog("gearcmd", "info", "START",
+		map[string]interface{}{"function": conf.FunctionName, "job_id": getJobId(job), "job_data": string(job.Data())}))
 	start := time.Now()
 	err := conf.doProcess(job)
 	end := time.Now()
@@ -40,9 +40,15 @@ func (conf TaskConfig) Process(job baseworker.Job) ([]byte, error) {
 	}
 	if err != nil {
 		data["error_message"] = err.Error()
-		log.Printf(kayvee.FormatLog("gearcmd", "error", "END_WITH_ERROR", data))
+		data["type"] = "gauge"
+		data["value"] = 0
+		data["success"] = false
+		log.Println(kayvee.FormatLog("gearcmd", "error", "END", data))
 	} else {
-		log.Printf(kayvee.FormatLog("gearcmd", "info", "END", data))
+		data["type"] = "gauge"
+		data["value"] = 1
+		data["success"] = true
+		log.Println(kayvee.FormatLog("gearcmd", "info", "END", data))
 		// Hopefully none of our jobs last long enough for a uint64...
 		log.Printf(kayvee.FormatLog("gearcmd", "info", "duration",
 			map[string]interface{}{

--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -36,16 +36,15 @@ func (conf TaskConfig) Process(job baseworker.Job) ([]byte, error) {
 	err := conf.doProcess(job)
 	end := time.Now()
 	data := map[string]interface{}{
-		"function": conf.FunctionName, "job_id": getJobId(job), "job_data": string(job.Data()),
+		"function": conf.FunctionName, "job_id": getJobId(job),
+		"job_data": string(job.Data()), "type": "gauge",
 	}
 	if err != nil {
 		data["error_message"] = err.Error()
-		data["type"] = "gauge"
 		data["value"] = 0
 		data["success"] = false
 		log.Println(kayvee.FormatLog("gearcmd", kayvee.Error, "END", data))
 	} else {
-		data["type"] = "gauge"
 		data["value"] = 1
 		data["success"] = true
 		log.Println(kayvee.FormatLog("gearcmd", kayvee.Info, "END", data))

--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/Clever/baseworker-go"
 	"github.com/Clever/gearcmd/argsparser"
-	"gopkg.in/Clever/kayvee-go.v1"
+	"gopkg.in/Clever/kayvee-go.v2"
 )
 
 // TaskConfig defines the configuration for the task.
@@ -30,7 +30,7 @@ type TaskConfig struct {
 // though the byte[] is always nil.
 func (conf TaskConfig) Process(job baseworker.Job) ([]byte, error) {
 	// This wraps the actual processing to do some logging
-	log.Println(kayvee.FormatLog("gearcmd", "info", "START",
+	log.Println(kayvee.FormatLog("gearcmd", kayvee.Info, "START",
 		map[string]interface{}{"function": conf.FunctionName, "job_id": getJobId(job), "job_data": string(job.Data())}))
 	start := time.Now()
 	err := conf.doProcess(job)
@@ -43,14 +43,14 @@ func (conf TaskConfig) Process(job baseworker.Job) ([]byte, error) {
 		data["type"] = "gauge"
 		data["value"] = 0
 		data["success"] = false
-		log.Println(kayvee.FormatLog("gearcmd", "error", "END", data))
+		log.Println(kayvee.FormatLog("gearcmd", kayvee.Error, "END", data))
 	} else {
 		data["type"] = "gauge"
 		data["value"] = 1
 		data["success"] = true
-		log.Println(kayvee.FormatLog("gearcmd", "info", "END", data))
+		log.Println(kayvee.FormatLog("gearcmd", kayvee.Info, "END", data))
 		// Hopefully none of our jobs last long enough for a uint64...
-		log.Printf(kayvee.FormatLog("gearcmd", "info", "duration",
+		log.Printf(kayvee.FormatLog("gearcmd", kayvee.Info, "duration",
 			map[string]interface{}{
 				"value": uint64(end.Sub(start).Seconds() * 1000),
 				"type":  "gauge", "function": conf.FunctionName,


### PR DESCRIPTION
The goal here is to log events and create alerts that will inform us if a worker fails. The END event is logged with extra data that can be parsed by Librato to generate graphs as well as alerts based on the event.

Known issues / problems:
- Librato alerts can alert the user if a particular metric changes within a duration. The max duration that it allows right now is 1 hour. This means that if a worker runs less than once an hour, it's average success rate used to trigger the alert will be same as the success rate of that event (binary: 0% or 100%).