### PR TITLE
Added log line of type counter.  Will be used for alerting.

### DIFF
--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -44,6 +44,18 @@ func (conf TaskConfig) Process(job baseworker.Job) ([]byte, error) {
 			"job_data": string(job.Data()),
 			"type":     "gauge",
 		}
+
+		var status string
+		if err == nil {
+			status = "success"
+		} else {
+			status = "failure"
+		}
+		log.Println(kayvee.FormatLog("gearcmd", kayvee.Info, status, map[string]interface{}{
+			"type":     "counter",
+			"function": conf.FunctionName,
+		}))
+
 		// Return if the job was successful.
 		if err == nil {
 			data["value"] = 1


### PR DESCRIPTION
**Why**: The goal is to alert on worker success/failure rates.  To that, we must first log the data in a convenient KayVee format.
**What**: On infra's recommendation, the following data is stored in the following fields:
```
source: <something>
title: <failure, or success>
type: counter [optional]
function: <worker name eg. ps, json_processor>
```
**Testing**: Ran unit tests and manually verified that the appropriate log lines are generated.

https://clever.atlassian.net/browse/DATA-1121