### PR TITLE
Go Vendoring Standardization

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2,7 +2,10 @@
 	"ImportPath": "github.com/Clever/gearcmd",
 	"GoVersion": "go1.5.1",
 	"Packages": [
-		"./..."
+		"github.com/Clever/gearcmd/argsparser",
+		"github.com/Clever/gearcmd/cmd/gearcmd",
+		"github.com/Clever/gearcmd/gearcmd",
+		"github.com/Clever/gearcmd/gearcmd/testscripts"
 	],
 	"Deps": [
 		{
@@ -11,7 +14,7 @@
 		},
 		{
 			"ImportPath": "github.com/Clever/discovery-go",
-			"Comment": "v1.1",
+			"Comment": "v1-12-gd77f9ad",
 			"Rev": "d77f9ad4526504b029218791389257ece92d7004"
 		},
 		{

--- a/Makefile
+++ b/Makefile
@@ -63,3 +63,15 @@ release: $(RELEASE_ARTIFACTS)
 
 clean:
 	rm -rf build release
+
+
+SHELL := /bin/bash
+PKGS := $(shell go list ./... | grep -v /vendor)
+GODEP := $(GOPATH)/bin/godep
+
+$(GODEP):
+	go get -u github.com/tools/godep
+
+vendor: $(GODEP)
+	$(GODEP) save $(PKGS)
+	find vendor/ -path '*/vendor' -type d | xargs -IX rm -r X # remove any nested vendor directories

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,7 @@
 VERSION := $(shell cat VERSION)
 SHELL := /bin/bash
 PKG = github.com/Clever/gearcmd/cmd/gearcmd
-SUBPKGS := \
-github.com/Clever/gearcmd/argsparser \
-github.com/Clever/gearcmd/gearcmd
-PKGS := $(PKG) $(SUBPKGS)
+PKGS := $(shell go list ./... | grep -v /vendor)
 EXECUTABLE := gearcmd
 BUILDS := \
 	build/$(EXECUTABLE)-v$(VERSION)-darwin-amd64 \
@@ -12,7 +9,7 @@ BUILDS := \
 COMPRESSED_BUILDS := $(BUILDS:%=%.tar.gz)
 RELEASE_ARTIFACTS := $(COMPRESSED_BUILDS:build/%=release/%)
 
-.PHONY: test $(PKGS) clean release
+.PHONY: test $(PKGS) clean release vendor
 
 GOVERSION := $(shell go version | grep 1.5)
 ifeq "$(GOVERSION)" ""
@@ -21,8 +18,13 @@ endif
 
 export GO15VENDOREXPERIMENT = 1
 
-$(GOPATH)/bin/golint:
-	@go get github.com/golang/lint/golint
+GOLINT := $(GOPATH)/bin/golint
+$(GOLINT):
+	go get github.com/golang/lint/golint
+
+GODEP := $(GOPATH)/bin/godep
+$(GODEP):
+	go get -u github.com/tools/godep
 
 
 test: $(PKGS)
@@ -30,7 +32,7 @@ test: $(PKGS)
 $(PKGS): cmd/gearcmd/version.go $(GOPATH)/bin/golint
 	@gofmt -w=true $(GOPATH)/src/$@*/**.go
 	@echo "LINTING..."
-	@$(GOPATH)/bin/golint $(GOPATH)/src/$@*/**.go
+	@$(GOLINT) $(GOPATH)/src/$@*/**.go
 	@echo ""
 ifeq ($(COVERAGE),1)
 	@go test -cover -coverprofile=$(GOPATH)/src/$@/c.out $@ -test.v
@@ -63,14 +65,6 @@ release: $(RELEASE_ARTIFACTS)
 
 clean:
 	rm -rf build release
-
-
-SHELL := /bin/bash
-PKGS := $(shell go list ./... | grep -v /vendor)
-GODEP := $(GOPATH)/bin/godep
-
-$(GODEP):
-	go get -u github.com/tools/godep
 
 vendor: $(GODEP)
 	$(GODEP) save $(PKGS)

--- a/README.md
+++ b/README.md
@@ -91,27 +91,7 @@ You can do this with [`gitsem`](https://github.com/clever/gitsem), but make sure
 
 2. Push the change to Github. Drone will automatically create a release for you.
 
-## Changing Dependencies
 
-### New Packages
+## Vendoring
 
-When adding a new package, you can simply use `make vendor` to update your imports.
-This should bring in the new dependency that was previously undeclared.
-The change should be reflected in [Godeps.json](Godeps/Godeps.json) as well as [vendor/](vendor/).
-
-### Existing Packages
-
-First ensure that you have your desired version of the package checked out in your `$GOPATH`.
-
-When to change the version of an existing package, you will need to use the godep tool.
-You must specify the package with the `update` command, if you use multiple subpackages of a repo you will need to specify all of them.
-So if you use package github.com/Clever/foo/a and github.com/Clever/foo/b, you will need to specify both a and b, not just foo.
-
-```
-# depending on github.com/Clever/foo
-godep update github.com/Clever/foo
-
-# depending on github.com/Clever/foo/a and github.com/Clever/foo/b
-godep update github.com/Clever/foo/a github.com/Clever/foo/b
-```
-
+Please view the [dev-handbook for instructions](https://github.com/Clever/dev-handbook/blob/master/golang/godep.md).

--- a/README.md
+++ b/README.md
@@ -90,3 +90,28 @@ To create an official release:
 You can do this with [`gitsem`](https://github.com/clever/gitsem), but make sure not to create the tag, e.g. `gitsem -tag=false patch`.
 
 2. Push the change to Github. Drone will automatically create a release for you.
+
+## Changing Dependencies
+
+### New Packages
+
+When adding a new package, you can simply use `make vendor` to update your imports.
+This should bring in the new dependency that was previously undeclared.
+The change should be reflected in [Godeps.json](Godeps/Godeps.json) as well as [vendor/](vendor/).
+
+### Existing Packages
+
+First ensure that you have your desired version of the package checked out in your `$GOPATH`.
+
+When to change the version of an existing package, you will need to use the godep tool.
+You must specify the package with the `update` command, if you use multiple subpackages of a repo you will need to specify all of them.
+So if you use package github.com/Clever/foo/a and github.com/Clever/foo/b, you will need to specify both a and b, not just foo.
+
+```
+# depending on github.com/Clever/foo
+godep update github.com/Clever/foo
+
+# depending on github.com/Clever/foo/a and github.com/Clever/foo/b
+godep update github.com/Clever/foo/a github.com/Clever/foo/b
+```
+

--- a/vendor/github.com/Clever/gearman-go/LICENSE
+++ b/vendor/github.com/Clever/gearman-go/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2011 by Xing Xing
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
This PR was mostly autogenerated.

Changes to expect:
- removal of `*_test.go` files in /vendor
- addition of non go files in /vendor
- addtions to README.md & Makefile

**Before your merge!**:

- Please carefully check the Makefile changes
- Ensure that the build is passing
- Check that drone is using the proper image (Clever/drone-go:1.5)

Feel free to ping @natebrennand or #golang for clarification or help.

If you'd like more of an explanation please join us in #golang.