### PR TITLE
insert gearman job id into job env

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Params:
 
 The command will be given as its arguments the exact arguments passed as the Gearman payload. These arguments will be parsed as if the command were being called in Bash. For example, running `gearcmd --name grep --cmd grep` and then submitting a Gearman job with function `grep` and payload `-i 'some regex' some-file.txt` would result in `grep` being run as if it were called on the command line like so: `grep -i 'some regex' some-file.txt`.
 
+The environment variable `JOB_ID` is injected while the job command is run. It is set to the job number of the gearman job being handled.
+
 #### Output
 
 - The command's stdout will be emitted as the Gearman worker's `WORK_DATA` events.

--- a/gearcmd/testscripts/output_env.sh
+++ b/gearcmd/testscripts/output_env.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# This test outputs the environment variables
+env

--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -20,11 +20,12 @@ import (
 
 // TaskConfig defines the configuration for the task.
 type TaskConfig struct {
-	FunctionName, FunctionCmd string
-	WarningLines              int
-	ParseArgs                 bool
-	CmdTimeout                time.Duration
-	RetryCount                int
+	FunctionName string
+	FunctionCmd  string
+	WarningLines int
+	ParseArgs    bool
+	CmdTimeout   time.Duration
+	RetryCount   int
 }
 
 // Process runs the Gearman job by running the configured task.
@@ -109,6 +110,10 @@ func (conf TaskConfig) doProcess(job baseworker.Job) error {
 		args = []string{string(job.Data())}
 	}
 	cmd := exec.Command(conf.FunctionCmd, args...)
+
+	// add the gearman job id to the env of the job
+	cmd.Env = append(os.Environ(), fmt.Sprintf("JOB_ID=%s", getJobID(job)))
+
 	// create new pgid for this process so we can later kill all subprocess launched by it
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 

--- a/gearcmd/worker_test.go
+++ b/gearcmd/worker_test.go
@@ -22,6 +22,7 @@ func getSuccessResponse(payload string, cmd string, t *testing.T) string {
 
 func getSuccessResponseWithConfig(payload string, config TaskConfig, t *testing.T) string {
 	mockJob := mock.CreateMockJob(payload)
+	mockJob.GearmanHandle = "H:lap:123"
 	_, err := config.Process(mockJob)
 	assert.Nil(t, err)
 	return string(mockJob.OutData())
@@ -176,4 +177,9 @@ func TestSendStderrWarnings(t *testing.T) {
 
 	assert.Nil(t, sendStderrWarnings(bytes.NewBufferString(stdErrStr), mockJob, 10))
 	assert.Equal(t, expectedStr, string(bytes.Join(mockJob.GearmanWarnings, []byte{})))
+}
+
+func TestEnvJobIDInsertion(t *testing.T) {
+	response := getSuccessResponse("", "testscripts/output_env.sh", t)
+	assert.Contains(t, strings.Split(response, "\n"), "JOB_ID=123")
 }


### PR DESCRIPTION
This adds the job id of a gearman job into the environment passed to the function as `JOB_ID`.