### PR TITLE
Use Go 1.6 in Drone and golang-version-check.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 env:
 - REPORT_CARD_GITHUB_STATUS_TOKEN=$$report_card_github_status_token
 - REPORT_CARD_GITHUB_REPO_TOKEN=$$report_card_github_repo_token
-image: clever/drone-go:1.5
+image: clever/drone-go:1.6
 notify:
   email:
     recipients:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ COMPRESSED_BUILDS := $(BUILDS:%=%.tar.gz)
 RELEASE_ARTIFACTS := $(COMPRESSED_BUILDS:build/%=release/%)
 .PHONY: test $(PKGS) clean release vendor
 
-$(eval $(call golang-version-check,1.5))
+$(eval $(call golang-version-check,1.6))
 
 all: test build
 


### PR DESCRIPTION
You were assigned as the most active recent contributor to this repo.
Please reassign and share the joy of Go 1.6 if needed, or ask in #golang
if you have any questions.
