### PR TITLE
Tweak heartbeat log format to pass to SignalFx

### DIFF
--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -154,6 +154,12 @@ func (conf TaskConfig) doProcess(job baseworker.Job, envVars []string, tryCount 
 				return
 			case <-ticker.C:
 				units++
+				lg.GaugeIntD("HEARTBEAT", units, logger.M{
+					"try_number": tryCount,
+					"function":   job.Fn(),
+					"job_id":     getJobID(job),
+					"unit":       tickUnit.String(),
+				})
 				legacyLg.GaugeIntD("heartbeat", units, logger.M{
 					"try_number": tryCount,
 					"function":   job.Fn(),

--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -154,7 +154,7 @@ func (conf TaskConfig) doProcess(job baseworker.Job, envVars []string, tryCount 
 				return
 			case <-ticker.C:
 				units++
-				lg.GaugeIntD("heartbeat", units, logger.M{
+				legacyLg.GaugeIntD("heartbeat", units, logger.M{
 					"try_number": tryCount,
 					"function":   job.Fn(),
 					"job_id":     getJobID(job),


### PR DESCRIPTION
Changes the heartbeat logline to emit from "gearman" instead of "gearcmd", for consistency's sake with our current log-router SignalFx outputs: https://github.com/Clever/log-router/blob/7b487f411718992d486d56e553b158e165f2f0de/config/data.toml#L28