### PR TITLE
Remove the legacy logger

### DIFF
--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -33,10 +33,6 @@ type TaskConfig struct {
 
 var (
 	lg = logger.New("gearcmd")
-	// legacy logger used to maintain existing alerts.
-	// Once all workers are migrated to using gearcmd >= v0.5.0 and the alarms are switched over,
-	// then we can remove this logger
-	legacyLg = logger.New("gearman")
 )
 
 // Process runs the Gearman job by running the configured task.
@@ -86,9 +82,6 @@ func (conf TaskConfig) Process(job baseworker.Job) (b []byte, returnErr error) {
 			lg.InfoD("SUCCESS", logger.M{
 				"type":     "counter",
 				"function": conf.FunctionName})
-			legacyLg.InfoD("success", logger.M{
-				"type":     "counter",
-				"function": conf.FunctionName})
 			data["value"] = 1
 			data["success"] = true
 			lg.InfoD("END", data)
@@ -114,7 +107,6 @@ func (conf TaskConfig) Process(job baseworker.Job) (b []byte, returnErr error) {
 	}
 
 	lg.InfoD("FAILURE", logger.M{"type": "counter", "function": conf.FunctionName})
-	legacyLg.InfoD("failure", logger.M{"type": "counter", "function": conf.FunctionName})
 	lg.ErrorD("END", data)
 	return nil, returnErr
 }


### PR DESCRIPTION
Between https://github.com/Clever/gitbot-scripts/blob/8cb359e10d1921dddc4230be760a611d2e1e2423/DISTRICTS-364 and manual grep/validation, I'm 99.999% certain that all active workers are using gearcmd >= 0.5.0.