### PR TITLE
send status when job started

### DIFF
--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -208,6 +208,7 @@ func (conf TaskConfig) doProcess(job baseworker.Job, envVars []string, tryCount 
 			return
 		}
 		close(started)
+		job.UpdateStatus(0, 1)
 		// Save the cmdErr. We want to process stdout and stderr before we return it
 		cmdErr := cmd.Wait()
 		stdoutWriter.Close()


### PR DESCRIPTION
This adds sending status as soon as job starts, so gearman admin can mark job as running