### PR TITLE
exit gearcmd on sigterm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ test: $(PKGS)
 $(PKGS): golang-test-all-deps cmd/gearcmd/version.go
 	$(call golang-test-all,$@)
 
-build/*: cmd/gearcmd/version.go bindata-kvconfig
 cmd/gearcmd/version.go: VERSION
 	@echo 'package main' > $@
 	@echo '' >> $@  # Write a go file that lints :)
@@ -38,7 +37,7 @@ build/$(EXECUTABLE)-v$(VERSION)-darwin-amd64:
 	GOARCH=amd64 GOOS=darwin go build -o "$@/$(EXECUTABLE)" $(PKG)
 build/$(EXECUTABLE)-v$(VERSION)-linux-amd64:
 	GOARCH=amd64 GOOS=linux go build -o "$@/$(EXECUTABLE)" $(PKG)
-build: clean $(BUILDS)
+build: clean cmd/gearcmd/version.go bindata-kvconfig $(BUILDS)
 
 %.tar.gz: %
 	tar -C `dirname $<` -zcvf "$<.tar.gz" `basename $<`

--- a/cmd/gearcmd/main.go
+++ b/cmd/gearcmd/main.go
@@ -75,7 +75,7 @@ func main() {
 	defer worker.Close()
 
 	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGTERM)
+	signal.Notify(sigc, syscall.SIGTERM, syscall.SIGINT)
 	go func() {
 		<-sigc
 		if *passSigterm {

--- a/cmd/gearcmd/main.go
+++ b/cmd/gearcmd/main.go
@@ -30,6 +30,7 @@ func main() {
 	retryCount := flag.Int("retry", 0, "Number of times to retry the job if it fails")
 	warningLength := flag.Int("warningLength", 5, "Number of warning lines to store and send back to the gearmn job")
 	passSigterm := flag.Bool("pass-sigterm", false, "Whether or not to pass SIGTERM through to the worker process")
+	sigtermGracePeriod := flag.Duration("sigterm-grace-period", 20*time.Second, "How long to wait after SIGTERM to send SIGKILL. 20s default.")
 	errorBackoffCount := flag.Int("error-backoff-count", 5, "How many errors in a row before we wait before erroring jobs")
 	errorBackoffRate := flag.Duration("error-backoff-rate", 5*time.Second, "How much time to sleep if last 'error-backoff-count' jobs have failed, e.g. 500ms, 1s")
 	flag.Parse()
@@ -70,6 +71,7 @@ func main() {
 		Halt:                    make(chan struct{}),
 		LastResults:             ring.New(*errorBackoffCount),
 		ErrorResultsBackoffRate: *errorBackoffRate,
+		SigtermGracePeriod:      *sigtermGracePeriod,
 	}
 	worker := baseworker.NewWorker(*functionName, config.ProcessWithErrorBackoff)
 	defer worker.Close()

--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -325,7 +325,9 @@ func stopProcess(p *os.Process, gracePeriod time.Duration) error {
 			targetID = -pgid
 		}
 		lg.InfoD("killing-pid", logger.M{"pid": p.Pid, "target_id": targetID})
-		syscall.Kill(targetID, syscall.SIGKILL)
+		if err := syscall.Kill(targetID, syscall.SIGKILL); err != nil {
+			lg.InfoD("unable-to-kill", logger.M{"pid": p.Pid, "target_id": targetID, "error": err.Error()})
+		}
 	})
 	lg.InfoD("waiting-pid", logger.M{"pid": p.Pid})
 	pState, err := p.Wait()

--- a/gearcmd/worker.go
+++ b/gearcmd/worker.go
@@ -34,6 +34,7 @@ type TaskConfig struct {
 	Halt                    chan struct{}
 	LastResults             *ring.Ring
 	ErrorResultsBackoffRate time.Duration
+	SigtermGracePeriod      time.Duration
 	// this variable tracks how much to backoff if another failure happens
 	currentErrorResultsBackoff time.Duration
 }
@@ -279,7 +280,7 @@ func (conf *TaskConfig) doProcess(job baseworker.Job, envVars []string, tryCount
 			// Will be nil if the channel was closed without any errors
 			return err
 		case <-conf.Halt:
-			if err := stopProcess(cmd.Process, conf.CmdTimeout); err != nil {
+			if err := stopProcess(cmd.Process, conf.SigtermGracePeriod); err != nil {
 				return fmt.Errorf("error stopping process: %s", err)
 			}
 			return fmt.Errorf("killed process due to sigterm")
@@ -303,34 +304,54 @@ func (conf *TaskConfig) doProcess(job baseworker.Job, envVars []string, tryCount
 	}
 }
 
-// stopProcess kills a given process. It's second argument is a grace period, if > 0, SIGTERM will
-// be sent first folloed by SIGKILL after the grace period is over. If the grace period is 0, this
-// is simply a hard SIGKILL.
+// stopProcess kills a given process. It's second argument is a grace period.
+// If, after the grace period, the process hasn't exited, SIGKILL will be sent.
+// It also calls os.Exit, since we currently rely on cutting off the connection
+// with gearmand to trigger reassignment of work to another worker.
 func stopProcess(p *os.Process, gracePeriod time.Duration) error {
 	lg.InfoD("stopping-process", logger.M{"pid": p.Pid, "grace_period": gracePeriod})
-	if gracePeriod > 0 {
-		// we use SIGTERM so that the subprocess can gracefully exit
-		if err := syscall.Kill(p.Pid, syscall.SIGTERM); err != nil {
-			return fmt.Errorf("unable to send SIGTERM, error: %s", err)
-		}
-		time.Sleep(gracePeriod)
+	if err := p.Signal(os.Signal(syscall.SIGTERM)); err != nil {
+		return fmt.Errorf("unable to send SIGTERM, error: %s", err)
 	}
-	// kill entire group of process spawned by our cmd.Process
-	targetID := p.Pid
-	pgid, err := syscall.Getpgid(p.Pid)
+	timer := time.AfterFunc(gracePeriod, func() {
+		// kill entire group of process spawned by our cmd.Process
+		targetID := p.Pid
+		pgid, err := syscall.Getpgid(p.Pid)
+		if err != nil {
+			lg.InfoD("unable-to-get-pgid", logger.M{"pid": p.Pid})
+		} else {
+			// minus sign required to kill PGIDs
+			// https://linux.die.net/man/2/kill
+			targetID = -pgid
+		}
+		lg.InfoD("killing-pid", logger.M{"pid": p.Pid, "target_id": targetID})
+		syscall.Kill(targetID, syscall.SIGKILL)
+	})
+	lg.InfoD("waiting-pid", logger.M{"pid": p.Pid})
+	pState, err := p.Wait()
+	timer.Stop()
 	if err != nil {
-		lg.InfoD("unable-to-get-pgid", logger.M{"pid": p.Pid})
-	} else {
-		// minus sign required to kill PGIDs
-		// https://linux.die.net/man/2/kill
-		targetID = -pgid
-	}
-	lg.InfoD("killing-pid", logger.M{"pid": p.Pid, "target_id": targetID})
-	if err := syscall.Kill(targetID, syscall.SIGKILL); err != nil {
-		// The graceful shutdown may have completed, so we don't error in that case.
-		if gracePeriod == 0 || !strings.Contains(err.Error(), "no such process") {
-			return fmt.Errorf("unable to send SIGKILL, error: %s", err)
+		if strings.Contains(err.Error(), "waitid: no child processes") {
+			// process was reaped before the call to Wait(), probably by sigterm handling in run script
+			lg.InfoD("process-exited-outside-of-gearcmd", logger.M{"pid": p.Pid, "code": -1})
+			os.Exit(0)
 		}
+		lg.ErrorD("unknown-wait-err", logger.M{"pid": p.Pid, "wait-err": err.Error()})
+		os.Exit(2)
+	}
+	status := pState.Sys().(syscall.WaitStatus)
+	switch {
+	case status.Exited() && status.ExitStatus() == 0:
+		lg.InfoD("process-exited", logger.M{"pid": p.Pid, "code": status.ExitStatus()})
+		os.Exit(0)
+	case status.Signaled() && status.Signal() == syscall.SIGKILL:
+		lg.ErrorD("process-killed", logger.M{"pid": p.Pid})
+		// Use a distinctive exit code to communicate that the cmd did not
+		// exit after receving SIGTERM
+		os.Exit(2)
+	default:
+		lg.ErrorD("process-in-unknown-state", logger.M{"pid": p.Pid, "state": pState.String()})
+		os.Exit(3)
 	}
 	return nil
 }


### PR DESCRIPTION
Currently when gearcmd is configured to pass SIGTERM the behavior is:
- forward that SIGTERM to the cmd
- If `cmdtimeout` is set, wait that amount of time. Since `cmdtimeout` is always super high (minutes, if not hours), this wait period never finishes and gearcmd gets SIGKILL'd after the 30s `docker stop` grace period in ECS

The killing of gearcmd triggers gearmand to reassign the work to another worker, which is nice, but it also means we don't know if the cmd exited cleanly.

This PR
 - adds a sigterm grace period param (we were previously defaulting to cmdtimeout, which is always set very high) with a default of 20s
 - changes sigterm handling logic to exit the gearcmd process itself, with an exit code equal to 0 if the cmd exited cleanly, nonzero otherwise.

I've manually tested this with schoolinsight and some other basic commands